### PR TITLE
SUPER CRITICAL CHANGE!!! ZOMG

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ TOKEN=<valid_github_api_token>
 
 Either use [poetry](https://python-poetry.org/) or activate a virtual environment (Python >=3.11) and run the following commands:
 ```shell
-git clone git@github.com:lu-pl/clscorgi.git
+git clone https://github.com/lu-pl/clscorgi.git
 cd clscorgi/
 pip install .
 ```


### PR DESCRIPTION
Super CRITICAL. ZOMG

Change default clone remote from ssh to https to smoothen the initial cloning since that is read-only anyway and is easier done over https instead of ssh.